### PR TITLE
Fixed potential crash cause + Version Bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 group 'fr.shyrogan'
-version '1.1.2'
+version '1.1.3'
 
 repositories {
     mavenCentral()

--- a/src/main/java/fr/shyrogan/post/utils/ReceiverCompiler.java
+++ b/src/main/java/fr/shyrogan/post/utils/ReceiverCompiler.java
@@ -185,7 +185,7 @@ public class ReceiverCompiler {
         for (Parameter parameter : method.getParameters()) {
             parameters.append(parameter.getType().getName().replace('.', '_'));
         }
-        return method.getName() + parameters.toString();
+        return method.getDeclaringClass().getName().replace('.', '_') + method.getName() + parameters.toString();
     }
 
 }


### PR DESCRIPTION
If you had 2 subscribed objects to the same topic, with the same method name, the generated Receiver class would only cast to the first one registered and would throw a ClassCastException whenever the second listener would be registered.